### PR TITLE
Correct icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,7 @@
   <content>
     <workbench>
       <name>SearchBar</name>
-      <icon>Tango-System-search.svg</icon>
+      <icon>Resources/Icons/Tango-System-search.svg</icon>
       <subdirectory>./</subdirectory>
       <tag>search</tag>
       <tag>widget</tag>


### PR DESCRIPTION
This needs to be the complete path to the icon, relative to the workbench's main directory (in this case `./`).